### PR TITLE
chore(router): base router 수정

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 
 ReactDOM.render(
-  <BrowserRouter basename="/json-navigator">
+  <BrowserRouter>
     <React.StrictMode>
       <App />
     </React.StrictMode>


### PR DESCRIPTION
- gh-pages 배포 시에는 루트 폴더와 github pages의 url이 일치하지 않아 빈 페이지가 나오는 이슈가 있어 `BrowserRouter`의 base router를 repo이름으로 지정해줘야 하나, gh-pages 배포 버전이 아닐 때에는 그럴 필요가 없음.
- 참고 : https://github.com/gitname/react-gh-pages/issues/3#issuecomment-399787987